### PR TITLE
:zap: Speed up bootstrapping using raid0 NVMe SSDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ devops/terraform/plan:
 devops/terraform/apply:
 	terraform -chdir=terraform/core apply -auto-approve
 
+devops/terraform/redeploy/reth_archive_node_vm_datadir_disk/%:
+	terraform -chdir=terraform/core apply \
+	-replace=module.reth_archive_node_vm[\"$*\"].google_compute_disk.datadir \
+	-target=module.reth_archive_node_vm[\"$*\"].google_compute_disk.datadir
+
 devops/terraform/redeploy/reth_archive_node_vm/%:
 	terraform -chdir=terraform/core apply \
 	-replace=module.reth_archive_node_vm[\"$*\"].google_compute_instance.this \

--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ But it could be overridden using the command below and updating the secret manag
 openssl rand -hex 32
 ```
 
+## Bootstraping
+
+Synchronizing the reth archive node from scratch can take a long time on network attached disk.
+For this reason it's possible to mount local NVMe SSDs in raid0 to speed up the process.
+It should only be used for the first syncing since this type of disk is designed for temporary storage.
+To bootstrap the node using NVMe set `bootstrap=true` and redeploy the node, e.g.
+
+```sh
+devops/terraform/redeploy/reth_archive_node_vm/node1
+```
+
+This will create a raid0 logical device mounted as `/mnt/disks/md0` on the host VM.
+Once the node is fully synced stop the reth container and copy the `/mnt/disks/md0` to the network attached persistent disk `/mnt/disks/sdb`.
+Disable bootstrapping `bootstrap=false` and redeploy the VM.
+
 ## Reaching a firewalled RPC
 
 If the node port is firewalled, it's possible to tunnel before accessing it.

--- a/terraform/core/format.sh
+++ b/terraform/core/format.sh
@@ -10,21 +10,49 @@ mount_command() {
   sudo chmod a+rwx /mnt/disks/$dev
 }
 
-for dev in $devs; do
-  # automatically resize/grow the partition if needed
-  e2fsck -f -y /dev/sdb
-  resize2fs /dev/sdb
-  sudo mkdir -p /mnt/disks/$dev
+mount_network_attached_devices() {
+  for dev in $devs; do
+    # automatically resize/grow the partition if needed
+    e2fsck -f -y /dev/$dev
+    resize2fs /dev/$dev
+    sudo mkdir -p /mnt/disks/$dev
+    # make sure the `mount` command fails gracefully using the `||`
+    # or the startup-script may be aborted entirely
+    RESULT=0
+    mount_command $dev || RESULT=1
+    if [ $RESULT -eq 0 ]; then
+      echo "Mounted /dev/$dev to /mnt/disks/$dev"
+    else
+      echo "Formatting /dev/$dev to ext4"
+      sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/$dev
+      mount_command $dev
+    fi
+  done
+}
+
+# mount all local NVMe en SSD as raid0
+# https://cloud.google.com/compute/docs/disks/add-local-ssd#formatmultiple
+mount_local_raid0() {
+  device_prefix=google-local-nvme-ssd
   # make sure the `mount` command fails gracefully using the `||`
   # or the startup-script may be aborted entirely
   RESULT=0
-  mount_command $dev || RESULT=1
+  # identify all of the local SSDs that we want to mount together
+  local_ssd=$(find /dev/ | grep $device_prefix) || RESULT=1
   if [ $RESULT -eq 0 ]; then
-    echo "Mounted /dev/$dev to /mnt/disks/$dev"
-  else
-    echo "Formatting /dev/$dev to ext4"
-    sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/$dev
+    dev=md0
+    device_count=$(echo "$local_ssd" | wc -l)
+    # combine multiple local SSD devices into a single array named /dev/$dev
+    sudo mdadm --create /dev/$dev --level=0 --raid-devices=$device_count $local_ssd
+    # confirm the details of the array
+    sudo mdadm --detail --prefer=by-id /dev/$dev
+    # format the full /dev/$dev array with an ext4 file system
+    sudo mkfs.ext4 -F /dev/$dev
+    sudo mkdir -p /mnt/disks/$dev
     mount_command $dev
   fi
-done
+}
+
+mount_network_attached_devices
+mount_local_raid0
 df -h

--- a/terraform/core/main.tf
+++ b/terraform/core/main.tf
@@ -61,10 +61,14 @@ module "reth_archive_node_vm" {
   reth_rpc_source_range = var.reth_rpc_source_range
   vm_tags               = var.reth_vm_tags
   # This has the permission to download images from Container Registry
-  client_email      = var.client_email
-  datadir_disk_size = var.reth_datadir_disk_size
-  volume_mounts     = local.volume_mounts
-  volumes           = local.volumes
+  client_email          = var.client_email
+  datadir_disk_size     = var.reth_datadir_disk_size
+  datadir_disk_snapshot = var.reth_datadir_disk_snapshot
+  scratch_disk_count    = local.scratch_disk_count
+  volume_mounts         = local.volume_mounts
+  volumes               = local.reth_volumes
+  # check logs with:
+  # sudo journalctl -u google-startup-scripts.service
   metadata_startup_script = join("\n", [
     data.local_file.format_script.content,
   ])
@@ -74,7 +78,7 @@ module "lighthouse_node_vm" {
   for_each        = toset(var.lighthouse_nodes)
   source          = "../gce-with-container"
   image           = var.lighthouse_image
-  custom_args     = local.lighthouse_custom_args
+  custom_args     = local.lighthouse_custom_args_map[each.value]
   privileged_mode = true
   activate_tty    = true
   machine_type    = var.lighthouse_machine_type
@@ -99,6 +103,8 @@ module "lighthouse_node_vm" {
   datadir_disk_size = var.lighthouse_datadir_disk_size
   volume_mounts     = local.volume_mounts
   volumes           = local.volumes
+  # check logs with:
+  # sudo journalctl -u google-startup-scripts.service
   metadata_startup_script = join("\n", [
     data.local_file.format_script.content,
   ])

--- a/terraform/gce-with-container/variables.tf
+++ b/terraform/gce-with-container/variables.tf
@@ -95,6 +95,12 @@ variable "datadir_disk_size" {
   default     = 100
 }
 
+variable "datadir_disk_snapshot" {
+  description = "Deploy the datadir disk from a snapshot unless empty."
+  type        = string
+  default     = null
+}
+
 variable "create_static_ip" {
   description = "Create a static IP"
   type        = bool
@@ -167,6 +173,12 @@ variable "client_email" {
 variable "metadata_startup_script" {
   type    = string
   default = ""
+}
+
+variable "scratch_disk_count" {
+  description = "Number of NVMe SSD disks to use for the raid0"
+  type        = number
+  default     = 0
 }
 
 variable "volume_mounts" {


### PR DESCRIPTION
Leverage temporary local SSD NVMe disks aka scratch disks to speed up initial node syncing.
The disks are setup in raid0 using an array of 8 SSDs of 375G each for a total of 3TB and mounted to /mnt/disks/md0.
This setup should only be used for the initial syncing as scratch disks aren't designed for persistent data.
After the initial syncing data should be copied over to the network attached persistent disk mounted to /mnt/disks/sdb. To toggle this setup update the bootstrap terraform variable and redeploy the VM.

Also note we use a C2 VM type for reth as it's still single threaded.
C2 types offer higher clock speed than the other types.

Find out more about the setup:
- https://cloud.google.com/compute/docs/disks/local-ssd
- https://cloud.google.com/compute/docs/disks/add-local-ssd