### PR TITLE
:wrench: Various fixes and version bumps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ devops/terraform/redeploy/reth_archive_node_vm/%:
 	terraform -chdir=terraform/core apply \
 	-replace=module.reth_archive_node_vm[\"$*\"].google_compute_instance.this \
 	-replace=module.reth_archive_node_vm[\"$*\"].google_compute_disk.boot \
+	-target=module.lighthouse_node_vm[\"does-not-exist-workaround\"] \
 	-target=module.reth_archive_node_vm[\"$*\"].google_compute_instance.this \
 	-target=module.reth_archive_node_vm[\"$*\"].google_compute_disk.boot \
 	-target=module.reth_archive_node_vm[\"$*\"]
@@ -35,11 +36,15 @@ devops/terraform/redeploy/lighthouse_node_vm/%:
 	terraform -chdir=terraform/core apply \
 	-replace=module.lighthouse_node_vm[\"$*\"].google_compute_instance.this \
 	-replace=module.lighthouse_node_vm[\"$*\"].google_compute_disk.boot \
+	-target=module.reth_archive_node_vm[\"does-not-exist-workaround\"] \
 	-target=module.lighthouse_node_vm[\"$*\"].google_compute_instance.this \
 	-target=module.lighthouse_node_vm[\"$*\"].google_compute_disk.boot \
 	-target=module.lighthouse_node_vm[\"$*\"]
 
 devops/terraform/redeploy/nodes: devops/terraform/redeploy/reth_archive_node_vm/node1
+
+devops/gcloud/reboot/vm/%:
+	gcloud compute instances reset $*
 
 devops/terraform/output:
 	terraform -chdir=terraform/core output

--- a/terraform/core/format.sh
+++ b/terraform/core/format.sh
@@ -1,6 +1,6 @@
 echo "$(hostname) $(date) Mounting attached disk"
 sudo lsblk
-part=$(sudo lsblk | grep 'part /' | grep -oh 'sd[a-z]1' | cut -c1-3 | uniq)
+part=$(sudo lsblk | grep --extended-regexp 'part +/' | grep -oh 'sd[a-z]1' | cut -c1-3 | uniq)
 echo "part=$part"
 devs=$(sudo lsblk | grep disk | grep -v $part | grep -oh 'sd[a-z]')
 echo "devs=$devs"

--- a/terraform/core/main.tf
+++ b/terraform/core/main.tf
@@ -106,7 +106,7 @@ module "lighthouse_node_vm" {
   client_email      = var.client_email
   datadir_disk_size = var.lighthouse_datadir_disk_size
   volume_mounts     = local.volume_mounts
-  volumes           = local.volumes
+  volumes           = local.prysm_volumes
   # check logs with:
   # sudo journalctl -u google-startup-scripts.service
   metadata_startup_script = join("\n", [

--- a/terraform/core/variables.tf
+++ b/terraform/core/variables.tf
@@ -36,12 +36,12 @@ variable "chain_name" {
 
 variable "reth_image" {
   type    = string
-  default = "ghcr.io/paradigmxyz/reth:v0.1.0-alpha.4"
+  default = "ghcr.io/paradigmxyz/reth:v0.1.0-alpha.10"
 }
 
 variable "lighthouse_image" {
   type    = string
-  default = "sigp/lighthouse:v4.3.0"
+  default = "sigp/lighthouse:v4.5.0"
 }
 
 variable "create_firewall_rule" {
@@ -87,7 +87,7 @@ variable "reth_datadir_disk_size" {
 
 variable "lighthouse_datadir_disk_size" {
   type    = number
-  default = 500
+  default = 1000
 }
 
 # consumed by both reth and lighthouse on their respective containers
@@ -197,11 +197,11 @@ locals {
       readOnly  = false
     },
   ]
-  volumes = [
+  prysm_volumes = [
     {
       name = "datadir"
       hostPath = {
-        path = var.bootstrap ? var.datadir_host_local_ssd_path : var.datadir_host_path
+        path = var.datadir_host_path
       }
     },
   ]


### PR DESCRIPTION
- update to reth:v0.1.0-alpha.10
- update to lighthouse:v4.5.0
- bump lighthouse disk size to 1T
- fix grep expression for volume mounting when raid0 is already mounted
- fix Makefile `redeploy` target to make sure other module resources don't get redeployed even if their configuration drifted